### PR TITLE
Rename master to canary.

### DIFF
--- a/active/0048-master-canary.md
+++ b/active/0048-master-canary.md
@@ -1,0 +1,18 @@
+- Start Date: 2016-04-04
+- RFC PR: #48
+
+# Summary
+
+Rename the `master` branch `canary`. We recognize that this is contentious and are seeking community feedback.
+
+# Motivation
+
+The goal is to make it a bit more clear which channel you're on without having to mirror commits between `master` and a `canary` branch.
+
+# Drawbacks
+
+This makes it a bit more confusing for new contributors to the project, but is neatly handled by GitHub's interface.
+
+# Alternatives
+
+Do nothing.


### PR DESCRIPTION
[Rendered](https://github.com/nathanhammond/ember-cli-rfcs/blob/master-canary/active/0048-master-canary.md)

We recognize that renaming `master` to `canary` is contentious. We're posting this for short-form feedback. **Please respond using reactions on this post!** We'll use that to gauge community interest, and engage in conversation on this if it seems like there is significant momentum in one direction or another.
