### PR TITLE
Cleanup merged RFCs

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,5 @@
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)
-- Ember CLI Issue: (leave this empty)
 
 # Summary
 

--- a/active/0003-ember-doctor.md
+++ b/active/0003-ember-doctor.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-01-10
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#3](https://github.com/ember-cli/rfcs/pull/3)
 
 # Summary
 

--- a/active/0020-sri-default.md
+++ b/active/0020-sri-default.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-07-10
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#20](https://github.com/ember-cli/rfcs/pull/20)
 
 # Summary
 

--- a/active/0023-command-line-completion.md
+++ b/active/0023-command-line-completion.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-08-18
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#23](https://github.com/ember-cli/rfcs/pull/23)
 
 # Summary
 

--- a/active/0029-addon-black-and-whitelist-for-apps.md
+++ b/active/0029-addon-black-and-whitelist-for-apps.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-11-11
 - RFC PR: [#29](https://github.com/ember-cli/rfcs/pull/29)
-- ember-cli Issue: (leave this empty)
 
 # Summary
 

--- a/active/0050-production-code-stripping.md
+++ b/active/0050-production-code-stripping.md
@@ -1,6 +1,5 @@
 - Start Date: 2016-04-06
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#50](https://github.com/ember-cli/rfcs/pull/50)
 
 # Summary
 

--- a/active/0055-anonymous-amd.md
+++ b/active/0055-anonymous-amd.md
@@ -1,6 +1,5 @@
-- Start Date: (fill me in with today's date, 2016-06-14)
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- Start Date: 2016-06-14
+- RFC PR: [#55](https://github.com/ember-cli/rfcs/pull/55)
 
 # Summary
 

--- a/active/0080-serve-file-api.md
+++ b/active/0080-serve-file-api.md
@@ -1,6 +1,5 @@
 - Start Date: 2016-11-21
-- RFC PR: (leave this empty)
-- Ember CLI Issue: (leave this empty)
+- RFC PR: [#80](https://github.com/ember-cli/rfcs/pull/80)
 
 # Summary
 

--- a/active/0090-addon-tree-caching.md
+++ b/active/0090-addon-tree-caching.md
@@ -1,9 +1,6 @@
-# Ember CLI Addon Deduplication
-
 - Start Date: 2016-12-11
-- RFC PR: https://github.com/ember-cli/rfcs/pull/90
-- Ember CLI Issue: (leave this empty)
- 
+- RFC PR: [#90](https://github.com/ember-cli/rfcs/pull/90)
+
 # Summary
 
 In Ember CLI today, all addons at each level are built through the standard `treeFor` / `treeFor*` hooks. These hooks are responsible for preprocessing the JavaScript included by the tree returned from that specific hook (e.g., `treeForAddon` preprocesses the JS for the addon tree). This RFC proposes a mechanism that would allow these returned trees to be cached by default (when no build time customization is done) and expose proper hooks for addon authors to control the degree to which we dedupe these trees.
@@ -12,7 +9,7 @@ In Ember CLI today, all addons at each level are built through the standard `tre
 
 Today, given the dependency graph:
 
-``` 
+```
 ember-basic-dropdown:
   ember-wormhole@0.4.1
 
@@ -28,7 +25,7 @@ We would actually build `ember-wormhole`'s `addon` tree 3 different times, even 
 
 - Add a `Addon.prototype.cacheKeyForTree` method to [lib/models/addon.js](https://github.com/ember-cli/ember-cli/commits/master/lib/models/addon.js) that is invoked prior to calling `treeFor` for the same tree name. The `Addon.prototype.cacheKeyForTree` method is expected to return a cache key allowing multiple builds of the same tree to simply return the original tree (preventing duplicate work). If `Addon.prototype.cacheKeyForTree` returns `null` / `undefined` the tree in question will opt out of this caching system.
 - ember-cli's custom [`mergeTrees` implementation](https://github.com/ember-cli/ember-cli/blob/4ec7b5951e8a9dd292029faf20d1858abf7bdfa0/lib/broccoli/merge-trees.js) (which is already aware of other tree reduction techniques) will be updated so that calling `mergeTrees([treeA, treeA]);` simply returns `treeA`, and `mergeTrees([treeA, treeB, treeA])` removes the duplicated `treeA` in the input nodes.
- 
+
 The proposed declaration for `Addon.prototype.cacheKeyForTree` in Typescript syntax is:
 
 ``` ts
@@ -40,12 +37,12 @@ The default implementation for `Addon.prototype.cacheKeyForTree` will:
     - `this.name` - The addon's name (generally from `package.json`).
     - `this.pkg` - This builds a checksum accounting for the addon's `package.json`.
     - `treeType` - The specific tree in question (e.g. `addon`, `vendor`, `addonTestSupport`, `templates`, etc).
- 
+
 - Resort to disabling all addon tree caching in the following scenarios
     - The addon implements a custom `treeFor`
     - The addon implements a custom `treeFor*` method (where `*` represents the tree type)
- 
- 
+
+
 Addons that implement custom `treeFor` or `treeFor*` methods can still opt-in to caching in scenarios that they can confirm are safe. To do this, they would implement a custom `cacheKeyForTree` method and return a cache key as appropriate for their caching needs.
 
 # How We Teach This
@@ -56,14 +53,14 @@ The following should help us teach this to the correct audience (roughly "addon 
 
 - Document the shared NPM package (referred to above as `calculate-cache-key-for-tree`). This will help authors of addons that need to implement `treeFor*` hooks understand how they can properly implement `Addon.prototype.cacheKeyForTree`.
 - Write API docs for the newly added `Addon.prototype.cacheKeyForTree` method.
- 
+
 # Drawbacks
 
 - Cache invalidation is difficult to get right, and it is possible to accidentally troll our users. This can be mitigated by thorough review of the implementation and this RFC.
- 
+
 # Alternatives
 
 # Unresolved questions
 
 - Confirm if including the same tree multiple times will only trigger a single build of that tree (this should be a Broccoli feature). We have confirmed that code exists in broccoli-builder ([see here](https://github.com/ember-cli/broccoli-builder/blob/0-18-x/lib/builder.js#L89-L97)), but still need to actually confirm `.build` / `.read` / `.rebuild` are not called twice within the same build.
- 
+

--- a/active/0091-addon-instrumentation-experimental-hooks.md
+++ b/active/0091-addon-instrumentation-experimental-hooks.md
@@ -1,6 +1,5 @@
-- Start Date: Wednesday, 14 December 2016
-- RFC PR: 
-- Ember CLI Issue: 
+- Start Date: 2016-12-14
+- RFC PR: [#91](https://github.com/ember-cli/rfcs/pull/91)
 
 # Summary
 
@@ -373,7 +372,7 @@ Returns an iterator that yields `[name, value]` pairs of stat names and values.
 
 Example:
 ```js
-  //  for a typical broccoli node 
+  //  for a typical broccoli node
   for ([statName, statValue] of node.statsIterator()) {
     console.log(statName, statValue);
   }

--- a/active/0092-blueprint-remove-old-files.md
+++ b/active/0092-blueprint-remove-old-files.md
@@ -1,6 +1,5 @@
 - Start Date: 2016-12-17
-- RFC PR: (leave this empty)
-- Ember CLI Issue: (leave this empty)
+- RFC PR: [#92](https://github.com/ember-cli/rfcs/pull/92)
 
 # Summary
 

--- a/active/0095-standardise-targets.md
+++ b/active/0095-standardise-targets.md
@@ -1,6 +1,5 @@
 - Start Date: 2017-01-03
-- RFC PR: https://github.com/ember-cli/rfcs/pull/95
-- Ember CLI Issue: (leave this empty)
+- RFC PR: [#95](https://github.com/ember-cli/rfcs/pull/95)
 
 # Summary
 
@@ -35,14 +34,14 @@ of Svelte Builds.
 
 # Detailed design
 
-What seems to be the most popular tool and the state of the art on building suport matrices 
+What seems to be the most popular tool and the state of the art on building suport matrices
 for browser targets is the [browserlist](https://github.com/ai/browserslist) npm package.
 
 That package is the one behind `babel-preset-env`, `autoprefixer` and others, and uses the data from
 [Can I Use](http://caniuse.com/) for knowing the JS, CSS and other APIs available on every browser.
 
-The syntax of this package is natural but also pretty flexible, allowing complex 
-queries like `Firefox >= 20`, `>2.5% in CA` (browsers with a market share over 2.5% in Canada) 
+The syntax of this package is natural but also pretty flexible, allowing complex
+queries like `Firefox >= 20`, `>2.5% in CA` (browsers with a market share over 2.5% in Canada)
 and logical combinations of the previous.
 
 The way this library work is by calculating the minimum common denominator support on a per-feature basis.
@@ -61,16 +60,16 @@ of it.
 ### Browser support
 
 The configution of target browsers must be placed in a file that allows javascript execution and exports an object
-with the configuration. The reason to prefer a javascript file over a JSON one is to allow users to 
+with the configuration. The reason to prefer a javascript file over a JSON one is to allow users to
 dinamically generate different config depending on things like the environment they are building the app in or
 any other environment variable.
 
-One possible location for this configuration is the `.ember-cli` file. 
+One possible location for this configuration is the `.ember-cli` file.
 A new dedicated named `/config/targets.js` also seems a good option, similar way how addons use `config/ember-try.js`
 to configure the test version matrix.
 
 Ember CLI will require this file when building the app and make the configuration available to addons
-in a `this.project.targets` property. 
+in a `this.project.targets` property.
 
 This `targets` object contains a getter named `browsers` that returns the provided configuration or the default
 one if the user didn't provide any.

--- a/active/0096-enable-yarn-usage.md
+++ b/active/0096-enable-yarn-usage.md
@@ -1,6 +1,5 @@
 - Start Date: 2017-02-02
-- RFC PR: (leave this empty)
-- Ember CLI Issue: (leave this empty)
+- RFC PR: [#96](https://github.com/ember-cli/rfcs/pull/96)
 
 # Summary
 

--- a/complete/0012-help-json-output.md
+++ b/complete/0012-help-json-output.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-05-16
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#12](https://github.com/ember-cli/rfcs/pull/12)
 
 # Summary
 

--- a/complete/0028-app-import-output-file.md
+++ b/complete/0028-app-import-output-file.md
@@ -1,6 +1,5 @@
 - Start Date: 2015-11-02
-- RFC PR: (leave this empty)
-- ember-cli Issue: (leave this empty)
+- RFC PR: [#28](https://github.com/ember-cli/rfcs/pull/28)
 
 # Summary
 


### PR DESCRIPTION
It was bugging me that the meta info for RFCs wasn't consistent and the majority of the RFCs had `0000-` as their prefix.

It also looks like the "Ember CLI Issue" field has never been used, so I propose removing it as it does not seem to be serving a purpose.